### PR TITLE
GAW-138: Fix Pieza desaparece en snapping

### DIFF
--- a/Unity/Assets/Clases/GameObjects/Prefab/Test/SnapTestPiece.prefab
+++ b/Unity/Assets/Clases/GameObjects/Prefab/Test/SnapTestPiece.prefab
@@ -14,7 +14,7 @@ GameObject:
   - component: {fileID: 5550672511212413527}
   - component: {fileID: 7622020744977153574}
   - component: {fileID: 6548270908248898323}
-  m_Layer: 0
+  m_Layer: 3
   m_Name: SnapTestPiece
   m_TagString: Object
   m_Icon: {fileID: 0}
@@ -118,7 +118,7 @@ Rigidbody:
   m_UseGravity: 0
   m_IsKinematic: 0
   m_Interpolate: 0
-  m_Constraints: 0
+  m_Constraints: 126
   m_CollisionDetection: 0
 --- !u!65 &7622020744977153574
 BoxCollider:
@@ -133,7 +133,7 @@ BoxCollider:
     m_Bits: 0
   m_ExcludeLayers:
     serializedVersion: 2
-    m_Bits: 0
+    m_Bits: 8
   m_LayerOverridePriority: 0
   m_IsTrigger: 0
   m_ProvidesContacts: 0
@@ -155,10 +155,10 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::SnappingPieceController
   moveSpeed: 6
   rotationSpeedDegPerSec: 120
-  positionSmoothTime: 0.07
   hoverHeight: 0.2
   enableGridSnap: 0
   cellSize: 1
   IsRotationFixed: 0
   snapAngle: 90
   snapRepeatDelay: 1
+  gridVisual: {fileID: 0}

--- a/Unity/Assets/Clases/Scenes/Standalone/SnappingPiece.unity
+++ b/Unity/Assets/Clases/Scenes/Standalone/SnappingPiece.unity
@@ -799,6 +799,7 @@ GameObject:
   - component: {fileID: 720584220}
   - component: {fileID: 720584215}
   - component: {fileID: 720584219}
+  - component: {fileID: 720584221}
   m_Layer: 0
   m_Name: Plane
   m_TagString: Untagged
@@ -853,7 +854,7 @@ MeshRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: -3033667219593020291, guid: dd3912619844a164385f7d1f544180a6, type: 3}
+  - {fileID: 2100000, guid: 3a554043ab1b996429dc354d47f6f3c3, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0
@@ -932,7 +933,26 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b0a5e8e1459e92448866306e6dd0ab62, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::BuildingZoneArea
-  gizmoColor: {r: 0, g: 0.6, b: 1, a: 0.15}
+  gizmoColor: {r: 1, g: 1, b: 1, a: 0.15}
+--- !u!114 &720584221
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 720584214}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8aecefd7666499e458180a3783913c8c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::GridController
+  plane: {fileID: 720584218}
+  manager: {fileID: 1142457341}
+  gridColor: {r: 0, g: 1, b: 0, a: 1}
+  lineWidth: 0.05
+  showInScene: 1
+  showInGame: 0
+  lineMaterial: {fileID: 0}
 --- !u!1 &738452973
 GameObject:
   m_ObjectHideFlags: 0
@@ -1044,6 +1064,88 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 738452973}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &750541609
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 750541612}
+  - component: {fileID: 750541611}
+  - component: {fileID: 750541610}
+  m_Layer: 0
+  m_Name: SnappingPieceController
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &750541610
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 750541609}
+  m_Enabled: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d24be6b0d43a5674b8f48cb41e1266c7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::SnappingPieceController
+  moveSpeed: 6
+  rotationSpeedDegPerSec: 240
+  hoverHeight: 0.2
+  enableGridSnap: 1
+  cellSize: 1
+  IsRotationFixed: 0
+  snapAngle: 90
+  snapRepeatDelay: 0.25
+  gridVisual: {fileID: 0}
+  boundaryObject: {fileID: 720584218}
+--- !u!54 &750541611
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 750541609}
+  serializedVersion: 5
+  m_Mass: 1
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
+  m_UseGravity: 1
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
+--- !u!4 &750541612
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 750541609}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 1.31091, y: 0.04, z: 5.14567}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &794853647
 GameObject:
   m_ObjectHideFlags: 0
@@ -1764,13 +1866,10 @@ MonoBehaviour:
   defaultRotSpeed: 120
   defaultHover: 0.2
   defaultGridSnap: 0
-  defaultCellSize: 0.5
+  defaultCellSize: 5
   defaultIsRotationFixed: 0
   moveAction: {fileID: -1680190386980627800, guid: 289c1b55c9541489481df5cc06664110, type: 3}
-  toggleModeAction: {fileID: 7404107289777399439, guid: 289c1b55c9541489481df5cc06664110, type: 3}
   dropAction: {fileID: 1869356181525620513, guid: 289c1b55c9541489481df5cc06664110, type: 3}
-  raiseAction: {fileID: 1716426203398813167, guid: 289c1b55c9541489481df5cc06664110, type: 3}
-  lowerAction: {fileID: 8176843600659610542, guid: 289c1b55c9541489481df5cc06664110, type: 3}
   startMode: 1
 --- !u!1 &1149614335
 GameObject:
@@ -2456,135 +2555,6 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1782071785}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
---- !u!1 &1790086257
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1790086262}
-  - component: {fileID: 1790086261}
-  - component: {fileID: 1790086260}
-  - component: {fileID: 1790086259}
-  - component: {fileID: 1790086258}
-  m_Layer: 0
-  m_Name: Quad
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!64 &1790086258
-MeshCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1790086257}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 5
-  m_Convex: 0
-  m_CookingOptions: 30
-  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
---- !u!114 &1790086259
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1790086257}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8aecefd7666499e458180a3783913c8c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: Assembly-CSharp::GridController
-  piece: {fileID: 6548270908248898323, guid: f48bf9125b9fa844abf475211b99bde6, type: 3}
-  cellSize: 1
-  yOffset: 0.05
-  followRotation: 0
---- !u!23 &1790086260
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1790086257}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RayTraceProcedural: 0
-  m_RayTracingAccelStructBuildFlagsOverride: 0
-  m_RayTracingAccelStructBuildFlags: 1
-  m_SmallMeshCulling: 1
-  m_ForceMeshLod: -1
-  m_MeshLodSelectionBias: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: a7e2818ca111cb745b7d444c21fc0864, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_GlobalIlluminationMeshLod: 0
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_AdditionalVertexStreams: {fileID: 0}
---- !u!33 &1790086261
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1790086257}
-  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
---- !u!4 &1790086262
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1790086257}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0.05, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1839592899
 GameObject:
   m_ObjectHideFlags: 0
@@ -2807,54 +2777,6 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2004922917}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
---- !u!1 &2006152245
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2006152247}
-  - component: {fileID: 2006152246}
-  m_Layer: 0
-  m_Name: Grid
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!114 &2006152246
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2006152245}
-  m_Enabled: 0
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8aecefd7666499e458180a3783913c8c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: Assembly-CSharp::GridController
-  piece: {fileID: 6548270908248898323, guid: f48bf9125b9fa844abf475211b99bde6, type: 3}
-  cellSize: 1
-  yOffset: 0.01
-  followRotation: 0
---- !u!4 &2006152247
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2006152245}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0.01, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2024644472
 GameObject:
   m_ObjectHideFlags: 0
@@ -2879,8 +2801,8 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2024644472}
   serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 3.05, y: 3.62, z: 3.22}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 3.05, y: 0.04, z: 2.62}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -3004,8 +2926,7 @@ SceneRoots:
   - {fileID: 1171086377}
   - {fileID: 1273799405}
   - {fileID: 1142457340}
-  - {fileID: 2006152247}
+  - {fileID: 750541612}
   - {fileID: 720584218}
-  - {fileID: 1790086262}
   - {fileID: 2024644473}
   - {fileID: 1149614336}

--- a/Unity/Assets/Clases/Scripts/SnappingPiece/GridController.cs
+++ b/Unity/Assets/Clases/Scripts/SnappingPiece/GridController.cs
@@ -3,54 +3,127 @@ using UnityEngine;
 [ExecuteAlways]
 public class GridController : MonoBehaviour
 {
-    [Header("Referencia a la pieza")]
-    public SnappingPieceController piece;
+    [Header("References")]
+    public Transform plane;
+    public SnapAssemblyPieceManager manager;
 
-    [Header("Ajustes del Grid")]
-    public float cellSize = 1f;
-    public float yOffset = 0.01f;   // Para que no se superponga al suelo
+    [Header("Grid Display")]
+    public Color gridColor = Color.green;
+    public float lineWidth = 0.05f;
 
-    [Header("Opcional")]
-    public bool followRotation = false;
+    [Header("Display Modes")]
+    public bool showInScene = true;
+    public bool showInGame = false;
+    public Material lineMaterial;
 
-    Renderer _renderer;
+    private float cellSize = 1f;
+    private int gridWidth;
+    private int gridHeight;
+    private bool needsUpdate = false;
 
-    void Awake()
+    private void Start()
     {
-        _renderer = GetComponent<Renderer>();
-    }
-
-    void Update()
-    {
-        if (piece == null) return;
-
-        Vector3Int cell = piece.CurrentGridCell;
-
-        // Convertir de celda a coordenadas del mundo
-        Vector3 worldPos = new Vector3(
-            cell.x * cellSize,
-            cell.y * cellSize,
-            cell.z * cellSize
-        );
-
-        // Ajustar para quedar justo sobre el piso
-        worldPos.y += yOffset;
-
-        transform.position = worldPos;
-
-        if (followRotation)
-            transform.rotation = piece.transform.rotation;
-        else
-            transform.rotation = Quaternion.identity;
-
-        transform.localScale = new Vector3(cellSize, 1f, cellSize);
-    }
-
-    public void SetColor(Color c)
-    {
-        if (_renderer != null)
+        if (showInGame && plane != null && manager != null)
         {
-            _renderer.material.color = c;
+            UpdateGridSize();
+            DrawGridInGame();
         }
+    }
+
+    private void Update()
+    {
+        if (needsUpdate)
+        {
+            if (showInGame && plane != null && manager != null)
+            {
+                UpdateGridSize();
+                DrawGridInGame();
+            }
+            needsUpdate = false;
+        }
+    }
+
+    public void UpdateGridSize()
+    {
+        if (plane == null || manager == null) return;
+
+        cellSize = manager.defaultCellSize;
+
+        Renderer r = plane.GetComponent<Renderer>();
+        if (r != null)
+        {
+            Vector3 size = r.bounds.size;
+            gridWidth = Mathf.RoundToInt(size.x / cellSize);
+            gridHeight = Mathf.RoundToInt(size.z / cellSize);
+        }
+    }
+
+    private void OnDrawGizmos()
+    {
+        if (!showInScene || plane == null || manager == null) return;
+
+        UpdateGridSize();
+        Gizmos.color = gridColor;
+
+        Vector3 origin = plane.position;
+        origin.x -= (gridWidth * cellSize) / 2f;
+        origin.z -= (gridHeight * cellSize) / 2f;
+
+        for (int x = 0; x <= gridWidth; x++)
+        {
+            Vector3 start = origin + new Vector3(x * cellSize, 0, 0);
+            Vector3 end = origin + new Vector3(x * cellSize, 0, gridHeight * cellSize);
+            Gizmos.DrawLine(start, end);
+        }
+
+        for (int z = 0; z <= gridHeight; z++)
+        {
+            Vector3 start = origin + new Vector3(0, 0, z * cellSize);
+            Vector3 end = origin + new Vector3(gridWidth * cellSize, 0, z * cellSize);
+            Gizmos.DrawLine(start, end);
+        }
+    }
+
+    private void DrawGridInGame()
+    {
+        Vector3 origin = plane.position;
+        origin.x -= (gridWidth * cellSize) / 2f;
+        origin.z -= (gridHeight * cellSize) / 2f;
+
+        for (int x = 0; x <= gridWidth; x++)
+        {
+            CreateLine(
+                origin + new Vector3(x * cellSize, 0, 0),
+                origin + new Vector3(x * cellSize, 0, gridHeight * cellSize)
+            );
+        }
+
+        for (int z = 0; z <= gridHeight; z++)
+        {
+            CreateLine(
+                origin + new Vector3(0, 0, z * cellSize),
+                origin + new Vector3(gridWidth * cellSize, 0, z * cellSize)
+            );
+        }
+    }
+
+    private void CreateLine(Vector3 start, Vector3 end)
+    {
+        GameObject lineObj = new GameObject("GridLine");
+        lineObj.transform.parent = transform;
+
+        LineRenderer lr = lineObj.AddComponent<LineRenderer>();
+        lr.material = lineMaterial != null
+            ? lineMaterial
+            : new Material(Shader.Find("Sprites/Default"));
+
+        lr.startColor = gridColor;
+        lr.endColor = gridColor;
+        lr.startWidth = lineWidth;
+        lr.endWidth = lineWidth;
+        lr.positionCount = 2;
+        lr.useWorldSpace = true;
+        lr.SetPosition(0, start);
+        lr.SetPosition(1, end);
     }
 }

--- a/Unity/Assets/Clases/Scripts/SnappingPiece/SnapAssemblyPieceManager.cs
+++ b/Unity/Assets/Clases/Scripts/SnappingPiece/SnapAssemblyPieceManager.cs
@@ -6,7 +6,6 @@ public class SnapAssemblyPieceManager : MonoBehaviour
 {
     [Header("Scene References")]
     public BuildingZoneArea buildingZone;
-    [Tooltip("Punto base de aparición (si está vacío, se usa el centro del BuildingZone).")]
     public Transform spawnPoint;
 
     [Header("Pieces")]
@@ -16,26 +15,20 @@ public class SnapAssemblyPieceManager : MonoBehaviour
     [Header("Active Piece Defaults")]
     public float defaultMoveSpeed = 6f;
     public float defaultRotSpeed = 120f;
-    public float defaultHover = 0.2f;
-    public bool defaultGridSnap = false;
-    public float defaultCellSize = 0.5f;
-    [Tooltip("Si true, la rotación será por pasos de 90°")]
+    public float defaultHover = 0.5f;
+    public bool defaultGridSnap = true;
+
+    [Range(0.5f, 5f)]
+    public float defaultCellSize = 5f;
+
     public bool defaultIsRotationFixed = false;
 
     [Header("Input (New Input System)")]
-    [Tooltip("Player/Move (Vector2)")]
     public InputActionReference moveAction;
-    [Tooltip("Player/ToggleAssemblyMode (Button) - T")]
-    public InputActionReference toggleModeAction;
-    [Tooltip("Player/PlacePiece (Button) - Enter")]
     public InputActionReference dropAction;
-    [Tooltip("Player/Raise (Button) - Space")]
-    public InputActionReference raiseAction;
-    [Tooltip("Player/Lower (Button) - Ctrl")]
-    public InputActionReference lowerAction;
 
     [Header("UI/Debug")]
-    public ManipulationModeSnap startMode = ManipulationModeSnap.Rotation;
+    public ManipulationModeSnap startMode = ManipulationModeSnap.Translation;
 
     int _spawnIndex = 0;
     SnappingPieceController _current;
@@ -43,19 +36,13 @@ public class SnapAssemblyPieceManager : MonoBehaviour
     void OnEnable()
     {
         moveAction?.action.Enable();
-        toggleModeAction?.action.Enable();
         dropAction?.action.Enable();
-        raiseAction?.action.Enable();
-        lowerAction?.action.Enable();
     }
 
     void OnDisable()
     {
         moveAction?.action.Disable();
-        toggleModeAction?.action.Disable();
         dropAction?.action.Disable();
-        raiseAction?.action.Disable();
-        lowerAction?.action.Disable();
     }
 
     void Start()
@@ -66,71 +53,58 @@ public class SnapAssemblyPieceManager : MonoBehaviour
             enabled = false; return;
         }
         SpawnNextPiece();
+
     }
 
     void Update()
     {
         if (_current == null) return;
 
-        // T: Rotación <-> Traslación
-        if (toggleModeAction != null && toggleModeAction.action.triggered)
-        {
-            var newMode = _current.mode == ManipulationModeSnap.Rotation
-                ? ManipulationModeSnap.Translation
-                : ManipulationModeSnap.Rotation;
-            _current.SetMode(newMode);
-        }
-
-        // Vector2 de flechas/WASD
         Vector2 arrows = moveAction != null ? moveAction.action.ReadValue<Vector2>() : Vector2.zero;
+        if (arrows != Vector2.zero)
+            _current.HandleArrows(arrows, Time.deltaTime);
 
-        // Vertical (Space/Ctrl) sólo en Traslación
-        float yInput = 0f;
-        if (raiseAction != null && raiseAction.action.IsPressed()) yInput += 1f;
-        if (lowerAction != null && lowerAction.action.IsPressed()) yInput -= 1f;
-
-        _current.HandleArrows(new Vector2(arrows.x, arrows.y), Time.deltaTime);
-        _current.HandleVertical(yInput, Time.deltaTime);
         _current.Tick(Time.deltaTime);
 
-        // Enter: soltar
         if (dropAction != null && dropAction.action.triggered)
+        {
             _current.BeginDrop();
+        }
     }
 
     void SpawnNextPiece()
     {
-        if (piecePrefabs.Count == 0)
-        {
-            Debug.LogError("AssemblyPieceManager: Agrega prefabs de piezas.");
-            return;
-        }
+        if (piecePrefabs.Count == 0) return;
 
         GameObject prefab = randomOrder
             ? piecePrefabs[Random.Range(0, piecePrefabs.Count)]
             : piecePrefabs[_spawnIndex++ % piecePrefabs.Count];
 
-        // Punto de aparición
         Vector3 pos; Quaternion rot = Quaternion.identity;
-        if (spawnPoint != null) { pos = spawnPoint.position; rot = spawnPoint.rotation; }
+        if (spawnPoint != null)
+        {
+            pos = spawnPoint.position;
+            rot = spawnPoint.rotation;
+        }
         else
         {
             var b = buildingZone.WorldBounds;
-            pos = new Vector3(b.center.x, b.min.y, b.center.z);
+            pos = new Vector3(b.center.x, b.min.y + defaultHover, b.center.z);
         }
 
         var go = Instantiate(prefab, pos, rot);
         var manip = go.GetComponent<SnappingPieceController>();
+        manip.cellSize = defaultCellSize;
+
         if (manip == null) manip = go.AddComponent<SnappingPieceController>();
 
-        // Defaults
+        // Configurar defaults
+        manip.cellSize = defaultCellSize;
+        manip.manager = this;
+        manip.buildingZone = buildingZone;
         manip.moveSpeed = defaultMoveSpeed;
         manip.rotationSpeedDegPerSec = defaultRotSpeed;
-        manip.hoverHeight = defaultHover;
-        manip.enableGridSnap = defaultGridSnap;
-        manip.cellSize = defaultCellSize;
         manip.IsRotationFixed = defaultIsRotationFixed;
-        manip.mode = startMode;
 
         manip.Activate(buildingZone, pos, rot);
         manip.OnPlaced += HandlePlaced;

--- a/Unity/Assets/Clases/Scripts/SnappingPiece/SnappingPieceController.cs
+++ b/Unity/Assets/Clases/Scripts/SnappingPiece/SnappingPieceController.cs
@@ -11,47 +11,46 @@ public class SnappingPieceController : MonoBehaviour
     public float moveSpeed = 6f;
     public float rotationSpeedDegPerSec = 240f;
 
-    [Header("Smoothing")]
-    [Tooltip("Tiempo de suavizado (mayor = más suave)")]
-    public float positionSmoothTime = 0.07f;
-
     [Header("Placement / Hover")]
-    [Tooltip("Altura a la que flota la pieza mientras la manipulas")]
     public float hoverHeight = 0.2f;
 
-    [Header("Grid (opcional)")]
+    [Header("Grid")]
     public bool enableGridSnap = true;
-    public float cellSize = 0.5f;
+    public float cellSize = 1f;
 
     [Header("Rotation Mode")]
-    [Tooltip("Si true, rotará en pasos de 90°; si false, rotación libre suave")]
     public bool IsRotationFixed = false;
-    public float snapAngle = 90f;                 // usado sólo si IsRotationFixed = true
-    public float snapRepeatDelay = 1f;//0.25f;         // repetición al mantener tecla (modo fijo)
+    public float snapAngle = 90f;
+    public float snapRepeatDelay = 0.25f;
 
-    [NonSerialized] public ManipulationModeSnap mode = ManipulationModeSnap.Rotation;
+    [Header("References")]
+    public GridController gridVisual;
+
+    [Header("Snapping Boundaries")]
+    public Transform boundaryObject;
+
+
+    [NonSerialized] public ManipulationModeSnap mode = ManipulationModeSnap.Translation;
+
+    [NonSerialized] public SnapAssemblyPieceManager manager;
+    [NonSerialized] public BuildingZoneArea buildingZone;
 
     Rigidbody _rb;
     Collider[] _colliders;
 
-    BuildingZoneArea _zone;
-
-    // Destino interpolado
     Vector3 _targetPos;
     Quaternion _targetRot;
     Vector3 _posVelRef;
-
-    // Acumulador crudo para traslación
     Vector3 _rawTargetPos;
 
-    // Estado para rotación fija
-    Vector2Int _lastSnapDir = Vector2Int.zero;
-    float _snapCooldown = 0f;
 
     bool _active = false;
     bool _dropping = false;
 
     public event Action<SnappingPieceController> OnPlaced;
+
+    float inputCooldown = 0.15f; 
+    float inputTimer = 0f;
 
     void Awake()
     {
@@ -62,145 +61,100 @@ public class SnappingPieceController : MonoBehaviour
 
     public void Activate(BuildingZoneArea zone, Vector3 spawnPos, Quaternion spawnRot)
     {
-        _zone = zone;
+        buildingZone = zone;
         _active = true;
         _dropping = false;
 
         transform.SetPositionAndRotation(spawnPos, spawnRot);
 
-        _targetPos = spawnPos;
-        _rawTargetPos = spawnPos;
         _targetRot = spawnRot;
 
         SetPreDropPhysics();
 
-        float minY = _zone.WorldBounds.min.y + hoverHeight;
-        _targetPos.y = Mathf.Max(spawnPos.y, minY);
-        _rawTargetPos.y = _targetPos.y;
+        float yBase = zone.WorldBounds.max.y + hoverHeight;
+        _targetPos = new Vector3(spawnPos.x, yBase, spawnPos.z);
+        _rawTargetPos = _targetPos;
         transform.position = _targetPos;
-    }
 
-    void SetPreDropPhysics()
-    {
-        if (_rb != null)
-        {
-            _rb.isKinematic = true;
-            _rb.useGravity = false;
-        }
-        if (_colliders != null)
-        {
-            foreach (var c in _colliders) c.isTrigger = true;
-        }
-    }
-
-    void SetPostDropPhysics()
-    {
-        if (_rb != null)
-        {
-            _rb.isKinematic = false;
-            _rb.useGravity = true;
-        }
-        if (_colliders != null)
-        {
-            foreach (var c in _colliders) c.isTrigger = false;
-        }
     }
 
     public void HandleArrows(Vector2 arrows, float deltaTime)
     {
         if (!_active || _dropping) return;
 
+        inputTimer -= deltaTime;
+        if (inputTimer > 0f) return;
+
         if (mode == ManipulationModeSnap.Translation)
         {
-            // Movimiento discretizado por celda
             int dx = arrows.x > 0.5f ? 1 : (arrows.x < -0.5f ? -1 : 0);
             int dz = arrows.y > 0.5f ? 1 : (arrows.y < -0.5f ? -1 : 0);
 
             if (dx != 0 || dz != 0)
             {
+                inputTimer = inputCooldown;
                 Vector3 step = new Vector3(dx * cellSize, 0f, dz * cellSize);
-                _rawTargetPos += step;
-            }
+                Vector3 candidate = _rawTargetPos + step;
 
-            // Snap directo
-            Vector3 dest = _rawTargetPos;
-
-            if (enableGridSnap && cellSize > 0.0001f)
-            {
-                dest.x = Mathf.Round(dest.x / cellSize) * cellSize;
-                dest.z = Mathf.Round(dest.z / cellSize) * cellSize;
-            }
-
-            dest = _zone.ClampInside(dest, GetHalfExtentsWorldXZ());
-
-            // Clamp Y usando extents de la pieza
-            var b = _zone.WorldBounds;
-            float halfY = GetHalfExtentsWorld().y;
-            float yMin = b.min.y + halfY;
-            float yMax = b.max.y - halfY;
-            dest.y = Mathf.Clamp(dest.y, yMin, yMax);
-
-            _targetPos = dest;
-        }
-        else // Rotation
-        {
-            if (!IsRotationFixed)
-            {
-                float yaw = arrows.x * rotationSpeedDegPerSec * deltaTime;
-                float pitch = -arrows.y * rotationSpeedDegPerSec * deltaTime; // arriba = +X
-                _targetRot = Quaternion.Euler(pitch, yaw, 0f) * _targetRot;
-            }
-            else
-            {
-                int dx = arrows.x > 0.5f ? 1 : (arrows.x < -0.5f ? -1 : 0);
-                int dy = arrows.y > 0.5f ? 1 : (arrows.y < -0.5f ? -1 : 0);
-                Vector2Int dir = new Vector2Int(dx, dy);
-
-                if (_snapCooldown > 0f) _snapCooldown -= deltaTime;
-
-                if (dir == Vector2Int.zero)
+                Bounds b;
+                if (boundaryObject != null)
                 {
-                    _lastSnapDir = Vector2Int.zero;
-                    _snapCooldown = 0f;
+                    Renderer r = boundaryObject.GetComponent<Renderer>();
+                    if (r != null)
+                    {
+                        b = r.bounds;
+                    }
+                    else
+                    {
+                        b = buildingZone.WorldBounds;
+                    }
                 }
-                else if (_snapCooldown <= 0f || dir != _lastSnapDir)
+                else
                 {
-                    Quaternion step = Quaternion.identity;
-                    if (dx != 0) step = Quaternion.Euler(0f, dx * snapAngle, 0f) * step;   // yaw
-                    if (dy != 0) step = Quaternion.Euler(-dy * snapAngle, 0f, 0f) * step;   // pitch
+                    b = buildingZone.WorldBounds;
+                }
 
-                    _targetRot = step * _targetRot;
-                    _lastSnapDir = dir;
-                    _snapCooldown = snapRepeatDelay;
+                float gridOriginX = b.min.x;
+                float gridOriginZ = b.min.z;
+
+                if (enableGridSnap && cellSize > 0.0001f)
+                {
+                    candidate.x = Mathf.Round((candidate.x - gridOriginX) / cellSize) * cellSize + gridOriginX;
+                    candidate.z = Mathf.Round((candidate.z - gridOriginZ) / cellSize) * cellSize + gridOriginZ;
+                }
+
+                candidate.x = Mathf.Clamp(candidate.x, b.min.x, b.max.x);
+                candidate.z = Mathf.Clamp(candidate.z, b.min.z, b.max.z);
+                candidate.y = b.max.y + hoverHeight;
+
+                if (candidate != _targetPos)
+                {
+                    _targetPos = candidate;
+                    _rawTargetPos = _targetPos; 
                 }
             }
         }
     }
 
-    public void HandleVertical(float yInput, float deltaTime)
+    void SetPreDropPhysics()
     {
-        if (!_active || _dropping || mode != ManipulationModeSnap.Translation) return;
-        if (Mathf.Approximately(yInput, 0f)) return;
+        _rb.isKinematic = true;
+        _rb.useGravity = false;
+        foreach (var c in _colliders) c.isTrigger = true;
+    }
 
-        _rawTargetPos.y += yInput * moveSpeed * deltaTime;
+    void SetPostDropPhysics()
+    {
+        _rb.isKinematic = false;
+        _rb.useGravity = true;
+        foreach (var c in _colliders) c.isTrigger = false;
     }
 
     public void Tick(float deltaTime)
     {
         if (!_active) return;
-
-        transform.position = Vector3.SmoothDamp(transform.position, _targetPos, ref _posVelRef, positionSmoothTime);
+        transform.position = Vector3.SmoothDamp(transform.position, _targetPos, ref _posVelRef, 0.07f);
         transform.rotation = Quaternion.RotateTowards(transform.rotation, _targetRot, rotationSpeedDegPerSec * deltaTime);
-    }
-
-    public void SetMode(ManipulationModeSnap newMode)
-    {
-        mode = newMode;
-        _targetPos = transform.position;
-        _rawTargetPos = transform.position;
-        _targetRot = transform.rotation;
-        _lastSnapDir = Vector2Int.zero;
-        _snapCooldown = 0f;
     }
 
     public void BeginDrop()
@@ -220,7 +174,6 @@ public class SnappingPieceController : MonoBehaviour
 
         while (true)
         {
-            if (_rb == null) break;
             if (_rb.linearVelocity.sqrMagnitude < velThreshold * velThreshold)
             {
                 stableTimer += Time.fixedDeltaTime;
@@ -234,7 +187,6 @@ public class SnappingPieceController : MonoBehaviour
         OnPlaced?.Invoke(this);
     }
 
-    // Coordenadas de la celda actual
     public Vector3Int CurrentGridCell
     {
         get
@@ -246,7 +198,6 @@ public class SnappingPieceController : MonoBehaviour
         }
     }
 
-    // Extents en mundo (considera rotación/escala)
     Vector3 GetHalfExtentsWorld()
     {
         var renderers = GetComponentsInChildren<Renderer>();
@@ -266,11 +217,5 @@ public class SnappingPieceController : MonoBehaviour
         }
 
         return new Vector3(0.25f, 0.25f, 0.25f);
-    }
-
-    Vector3 GetHalfExtentsWorldXZ()
-    {
-        var e = GetHalfExtentsWorld();
-        return new Vector3(e.x, 0f, e.z);
     }
 }


### PR DESCRIPTION
# Resumen de cambios - Snapping de piezas

## Mejoras implementadas
- Movimiento por Input System  
  - Se conectaron las flechas/joystick para mover piezas.  
  - Se agregó control con `MoveAction` y debug para validar inputs.  

- Snapping en cuadrícula  
  - El movimiento ahora es por celdas, no libre.  
  - Se ajustó el cálculo para evitar desalineación.  
  - Se agregaron límites para que las piezas no salgan del plano.  

- Bug de pieza desaparecida (#138)  
  - Al presionar Enter, antes la pieza desaparecía.  
  - Ahora la pieza se queda fija en la cuadrícula y se spawnea otra.  

- Grid dinámico  
  - El tamaño de celda se puede modificar con slider en el editor.  
  - Las piezas ya activas también se actualizan al nuevo tamaño.  

- Visualización de cuadrícula  
  - Se agregó renderizado de líneas para depuración.  
  - El grid se ajusta al tamaño del plano asignado.  

## Resultado final
- Las piezas ya no desaparecen.  
- Se mueven por la cuadrícula, respetando los bordes.  
- Al presionar Enter, la pieza se fija y aparece otra lista.  
- El grid es configurable en tiempo real y visible en escena.  
