### PR TITLE
GAW-165: Brick como modelo

### DIFF
--- a/Unity/Assets/Clases/Scenes.meta
+++ b/Unity/Assets/Clases/Scenes.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6fd04010852edab44a9c3bb771f9d428
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity/Assets/Clases/Scenes/Game.meta
+++ b/Unity/Assets/Clases/Scenes/Game.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e85247601291446499f81518720df6cb
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity/Assets/Clases/Scripts/Controller/Objetos/BrickBehavior.cs
+++ b/Unity/Assets/Clases/Scripts/Controller/Objetos/BrickBehavior.cs
@@ -1,0 +1,44 @@
+// BrickBehavior.cs
+using UnityEngine;
+
+[RequireComponent(typeof(Rigidbody))]
+public class BrickBehavior : MonoBehaviour, IInteractable
+{
+    private Rigidbody rb;
+    public Brick Model { get; private set; }
+
+    public bool IsHeld => Model.IsHeld;
+    public PlayerController CurrentHolder => Model.CurrentHolder;
+
+    private void Awake()
+    {
+        rb = GetComponent<Rigidbody>();
+        Model = new Brick();
+    }
+
+    public void Interact(PlayerController player)
+    {
+        var oi = player.GetComponent<ObjectInteraction>();
+        if (oi != null) oi.ForcePickup(gameObject, player);
+    }
+
+    public void OnPickedUp(PlayerController player)
+    {
+
+        Model.PickUp(player);
+
+        rb.linearVelocity = Vector3.zero;
+        rb.angularVelocity = Vector3.zero;
+
+        rb.useGravity = false;
+        rb.isKinematic = true;
+    }
+
+    public void OnDropped()
+    {
+        Model.Drop();
+
+        rb.isKinematic = false;
+        rb.useGravity = true;
+    }
+}

--- a/Unity/Assets/Clases/Scripts/Controller/Objetos/BrickBehavior.cs.meta
+++ b/Unity/Assets/Clases/Scripts/Controller/Objetos/BrickBehavior.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5c8e48ca156a6364696f14d2870ac256

--- a/Unity/Assets/Clases/Scripts/Controller/Player/ObjectInteraction.cs
+++ b/Unity/Assets/Clases/Scripts/Controller/Player/ObjectInteraction.cs
@@ -38,7 +38,7 @@ public class ObjectInteraction : MonoBehaviour
         Collider[] cols = Physics.OverlapSphere(transform.position, interactionRadius, interactableMask);
         foreach (var col in cols)
         {
-            var brick = col.GetComponent<Brick>();
+            var brick = col.GetComponent<BrickBehavior>();
             if (brick != null)
             {
                 PickUpObject(brick.gameObject, player);
@@ -61,7 +61,7 @@ public class ObjectInteraction : MonoBehaviour
     public void ForcePickup(GameObject obj, PlayerController player)
     {
         if (obj == null || player == null) return;
-        var brickComp = obj.GetComponent<Brick>();
+        var brickComp = obj.GetComponent<BrickBehavior>();
         if (brickComp != null && brickComp.IsHeld && brickComp.CurrentHolder != null)
         {
             var prevHolder = brickComp.CurrentHolder;
@@ -119,7 +119,7 @@ public class ObjectInteraction : MonoBehaviour
         pickedObject = obj;
         owner = player;
 
-        var brick = obj.GetComponent<Brick>();
+        var brick = obj.GetComponent<BrickBehavior>();
         if (brick != null) brick.OnPickedUp(player);
 
         if (player != null) player.CanJump = false;
@@ -138,7 +138,7 @@ public class ObjectInteraction : MonoBehaviour
 
         pickedObject.transform.SetParent(null);
 
-        var brick = pickedObject.GetComponent<Brick>();
+        var brick = pickedObject.GetComponent<BrickBehavior>();
         if (brick != null) brick.OnDropped();
 
         pickedObject = null;
@@ -162,7 +162,7 @@ public class ObjectInteraction : MonoBehaviour
             rb.useGravity = true;
         }
 
-        var brickComp = obj.GetComponent<Brick>();
+        var brickComp = obj.GetComponent<BrickBehavior>();
         if (brickComp != null) brickComp.OnDropped();
 
         Transform basis = player.cameraRoot ? player.cameraRoot : player.transform;

--- a/Unity/Assets/Clases/Scripts/Interfaces/IInteractable.cs
+++ b/Unity/Assets/Clases/Scripts/Interfaces/IInteractable.cs
@@ -2,4 +2,6 @@
 public interface IInteractable
 {
     void Interact(PlayerController player);
+    void OnPickedUp(PlayerController player);
+    void OnDropped();
 }

--- a/Unity/Assets/Clases/Scripts/Models/Brick/Brick.cs
+++ b/Unity/Assets/Clases/Scripts/Models/Brick/Brick.cs
@@ -1,37 +1,18 @@
-// Brick.cs
-using UnityEngine;
-
-[RequireComponent(typeof(Rigidbody))]
-public class Brick : MonoBehaviour, IInteractable
+// Brick.cs  (MODEL)
+public class Brick
 {
-    Rigidbody rb;
     public bool IsHeld { get; private set; } = false;
     public PlayerController CurrentHolder { get; private set; }
 
-    void Awake()
-    {
-        rb = GetComponent<Rigidbody>();
-    }
-
-    public void Interact(PlayerController player)
-    {
-        var oi = player.GetComponent<ObjectInteraction>();
-        if (oi != null) oi.ForcePickup(gameObject, player);
-    }
-    public void OnPickedUp(PlayerController player)
+    public void PickUp(PlayerController player)
     {
         IsHeld = true;
         CurrentHolder = player;
-        rb.linearVelocity = Vector3.zero;
-        rb.angularVelocity = Vector3.zero;
-        rb.useGravity = false;
-        rb.isKinematic = true;
     }
-    public void OnDropped()
+
+    public void Drop()
     {
         IsHeld = false;
         CurrentHolder = null;
-        rb.isKinematic = false;
-        rb.useGravity = true;
     }
 }

--- a/Unity/Assets/Scenes/Standalone/PieceTransfer.unity
+++ b/Unity/Assets/Scenes/Standalone/PieceTransfer.unity
@@ -124,7 +124,7 @@ GameObject:
   m_CorrespondingSourceObject: {fileID: 7522482001035022091, guid: 6629d2f4da442f146b880670e84e6eef, type: 3}
   m_PrefabInstance: {fileID: 614216129}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &445685962
+--- !u!114 &445685969
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -133,9 +133,9 @@ MonoBehaviour:
   m_GameObject: {fileID: 445685955}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 573876023877b7e47a20467ed198952d, type: 3}
+  m_Script: {fileID: 11500000, guid: 5c8e48ca156a6364696f14d2870ac256, type: 3}
   m_Name: 
-  m_EditorClassIdentifier: Assembly-CSharp::Brick
+  m_EditorClassIdentifier: Assembly-CSharp::BrickBehavior
 --- !u!1001 &614216129
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -214,7 +214,7 @@ PrefabInstance:
     m_AddedComponents:
     - targetCorrespondingSourceObject: {fileID: 7522482001035022091, guid: 6629d2f4da442f146b880670e84e6eef, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 445685962}
+      addedObject: {fileID: 445685969}
   m_SourcePrefab: {fileID: 100100000, guid: 6629d2f4da442f146b880670e84e6eef, type: 3}
 --- !u!1 &935905552
 GameObject:


### PR DESCRIPTION
-Ahora "Brick" ya no deriva de MonoBehavior
-Se creó un nuevo script "BrickBehavior" el cual sí deriva de Monobehavior. 
-Brick ahora funciona como un Model.
-Se modificaron todos los scripts necesarios para que todo siga funcionando igual.